### PR TITLE
Update Dependabot configuration for Python packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    target-branch: "feature/dependency-updates"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      python:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Configured Dependabot to update Python dependencies weekly on Mondays at 09:00 AM EST.